### PR TITLE
:green_heart: disable arm builds

### DIFF
--- a/.tekton/main-pull-request.yaml
+++ b/.tekton/main-pull-request.yaml
@@ -30,6 +30,9 @@ spec:
     value: .
   - name: target-stage
     value: test
+  - name: build-platforms
+    value:
+    - linux/amd64
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/main-push.yaml
+++ b/.tekton/main-push.yaml
@@ -27,6 +27,9 @@ spec:
     value: .
   - name: target-stage
     value: prod
+  - name: build-platforms
+    value:
+    - linux/amd64
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
ARM builds are very slow. Disable them until the performance has been improved.