### PR TITLE
Handle no outputs file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi9/python-311@sha256:753524c12d1feb344133d6074994498fbbfea8078cef75eb9b90c37fd5db5f3a AS base
 # er-outputs-secrets version. keep in sync with pyproject.toml
-LABEL konflux.additional-tags="0.2.2"
+LABEL konflux.additional-tags="0.2.3"
 COPY LICENSE /licenses/
 
 

--- a/main.py
+++ b/main.py
@@ -65,7 +65,7 @@ def save_outputs(
             raise e
 
 
-def main():
+def main() -> None:
     input_data = read_input_from_file()
     provision: AppInterfaceProvision = parse_model(
         AppInterfaceProvision, input_data["provision"]

--- a/main.py
+++ b/main.py
@@ -3,7 +3,6 @@ import hashlib
 import json
 import logging
 import os
-import sys
 from pathlib import Path
 
 from external_resources_io.input import (
@@ -63,24 +62,20 @@ def save_outputs(
             raise e
 
 
-if __name__ == "__main__":
+def main():
     input_data = read_input_from_file()
     provision: AppInterfaceProvision = parse_model(
         AppInterfaceProvision, input_data["provision"]
     )
-
     namespace = os.environ["NAMESPACE"]
     action = os.environ["ACTION"]
     dry_run = os.environ["DRY_RUN"]
-
     if dry_run == "True":
         logging.info("DRY_RUN does not store any secret")
-        sys.exit(0)
-
+        return
     if action == "Destroy":
         logging.info("No outputs management on Destroy Action")
-        sys.exit(0)
-
+        return
     if action == "Apply":
         secret = V1Secret(
             api_version="v1",
@@ -94,3 +89,7 @@ if __name__ == "__main__":
         )
         k8s_client = get_k8s_client()
         save_outputs(k8s_client, namespace, secret)
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import logging
 import os
 from pathlib import Path
 
+from external_resources_io.config import Action, Config
 from external_resources_io.input import (
     AppInterfaceProvision,
     parse_model,
@@ -14,6 +15,8 @@ from kubernetes import config
 from kubernetes.client import CoreV1Api, V1ObjectMeta, V1Secret
 from kubernetes.client.exceptions import ApiException
 from kubernetes.dynamic.exceptions import NotFoundError, api_exception
+
+OUTPUTS_FILE = "/work/output.json"
 
 logging.basicConfig(level=logging.INFO)
 
@@ -68,27 +71,33 @@ def main():
         AppInterfaceProvision, input_data["provision"]
     )
     namespace = os.environ["NAMESPACE"]
-    action = os.environ["ACTION"]
-    dry_run = os.environ["DRY_RUN"]
-    if dry_run == "True":
+    conf = Config()
+    if conf.dry_run:
         logging.info("DRY_RUN does not store any secret")
         return
-    if action == "Destroy":
-        logging.info("No outputs management on Destroy Action")
-        return
-    if action == "Apply":
-        secret = V1Secret(
-            api_version="v1",
-            metadata=V1ObjectMeta(
-                name=get_secret_name(provision),
-                annotations=provision.model_dump(exclude={"module_provision_data"}),
-            ),
-            data=read_outputs(
-                terraform_output=Path("/work/output.json").read_text(encoding="locale")
-            ),
-        )
-        k8s_client = get_k8s_client()
-        save_outputs(k8s_client, namespace, secret)
+
+    match conf.action:
+        case Action.DESTROY:
+            logging.info("No outputs management on Destroy Action")
+        case Action.APPLY:
+            output_file = Path(OUTPUTS_FILE)
+            if not output_file.exists():
+                logging.info(
+                    f"No output file found at {OUTPUTS_FILE}, skip output management"
+                )
+                return
+            secret = V1Secret(
+                api_version="v1",
+                metadata=V1ObjectMeta(
+                    name=get_secret_name(provision),
+                    annotations=provision.model_dump(exclude={"module_provision_data"}),
+                ),
+                data=read_outputs(
+                    terraform_output=output_file.read_text(encoding="locale")
+                ),
+            )
+            k8s_client = get_k8s_client()
+            save_outputs(k8s_client, namespace, secret)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ known-first-party = ["main"]
 
 # Mypy configuration
 [tool.mypy]
+plugins = ["pydantic.mypy"]
 files = ["main.py", "tests"]
 enable_error_code = ["truthy-bool", "redundant-expr"]
 no_implicit_optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "er-outputs-secrets"
 # keep in sync with Dockerfile
-version = "0.2.2"
+version = "0.2.3"
 description = "Parse terraform outputs and create k8s secrets"
 authors = [{ name = "AppSRE", email = "sd-app-sre@redhat.com" }]
 license = { text = "MIT License" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,9 @@ license = { text = "MIT License" }
 readme = "README.md"
 requires-python = "~= 3.11.0"
 dependencies = [
-    # allow updates for patch versions only
-    "anymarkup ~=0.8.1",
-    "external-resources-io ~=0.5.1",
-    "kubernetes ~=31.0.0",
-    "pydantic ~=2.10.0",
+    "external-resources-io==0.6.1",
+    "kubernetes==32.0.1",
+    "pydantic==2.10.6",
 ]
 
 [project.urls]
@@ -22,11 +20,10 @@ documentation = "https://github.com/app-sre/er-outputs-secretse"
 
 [dependency-groups]
 dev = [
-    # allow updates for minor versions
-    "ruff ~=0.7",
-    "mypy ~=1.13",
-    "pytest ~=8.3",
-    "pytest-cov ~=6.0",
+    "mypy==1.15.0",
+    "pytest-cov==6.0.0",
+    "pytest==8.3.5",
+    "ruff==0.11.0",
 ]
 
 # Ruff configuration

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,10 @@ from external_resources_io.input import AppInterfaceProvision, TerraformProvisio
 sys.path.append(str(Path(__file__).parent.parent))
 
 
+DEFAULT_EXPECTED_SECRET_NAME = "external-resources-output-6d9eb7ec5e128634012e28f84506de80"
+DEFAULT_TERRAFORM_OUTPUT = '{"output1": {"value": "output1_value"}, "output2": {"value": 12345}}'
+DEFAULT_EXPECTED_OUTPUTS = {"output1": "b3V0cHV0MV92YWx1ZQ==", "output2": "MTIzNDU="}
+
 @pytest.fixture
 def provision() -> AppInterfaceProvision:
     return AppInterfaceProvision(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,14 @@ from external_resources_io.input import AppInterfaceProvision, TerraformProvisio
 sys.path.append(str(Path(__file__).parent.parent))
 
 
-DEFAULT_EXPECTED_SECRET_NAME = "external-resources-output-6d9eb7ec5e128634012e28f84506de80"
-DEFAULT_TERRAFORM_OUTPUT = '{"output1": {"value": "output1_value"}, "output2": {"value": 12345}}'
+DEFAULT_EXPECTED_SECRET_NAME = (
+    "external-resources-output-6d9eb7ec5e128634012e28f84506de80"
+)
+DEFAULT_TERRAFORM_OUTPUT = (
+    '{"output1": {"value": "output1_value"}, "output2": {"value": 12345}}'
+)
 DEFAULT_EXPECTED_OUTPUTS = {"output1": "b3V0cHV0MV92YWx1ZQ==", "output2": "MTIzNDU="}
+
 
 @pytest.fixture
 def provision() -> AppInterfaceProvision:

--- a/tests/test_get_secret_name.py
+++ b/tests/test_get_secret_name.py
@@ -1,0 +1,8 @@
+from external_resources_io.input import AppInterfaceProvision
+from tests.conftest import DEFAULT_EXPECTED_SECRET_NAME
+
+from main import get_secret_name
+
+
+def test_get_secret_name(provision: AppInterfaceProvision) -> None:
+    assert get_secret_name(provision) == DEFAULT_EXPECTED_SECRET_NAME

--- a/tests/test_get_secret_name.py
+++ b/tests/test_get_secret_name.py
@@ -1,7 +1,7 @@
 from external_resources_io.input import AppInterfaceProvision
-from tests.conftest import DEFAULT_EXPECTED_SECRET_NAME
 
 from main import get_secret_name
+from tests.conftest import DEFAULT_EXPECTED_SECRET_NAME
 
 
 def test_get_secret_name(provision: AppInterfaceProvision) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,10 +1,132 @@
+import os
+from collections.abc import Iterator
+from unittest.mock import Mock, patch
+
+import pytest
 from external_resources_io.input import AppInterfaceProvision
+from kubernetes.client import ApiException, V1ObjectMeta, V1Secret
+from tests.conftest import (
+    DEFAULT_EXPECTED_OUTPUTS,
+    DEFAULT_EXPECTED_SECRET_NAME,
+    DEFAULT_TERRAFORM_OUTPUT,
+)
 
-from main import get_secret_name
+from main import main
 
 
-def test_get_secret_name(provision: AppInterfaceProvision) -> None:
-    assert (
-        get_secret_name(provision)
-        == "external-resources-output-6d9eb7ec5e128634012e28f84506de80"
+@pytest.fixture
+def mock_read_input_from_file() -> Iterator[Mock]:
+    with patch("main.read_input_from_file") as m:
+        yield m
+
+
+@pytest.fixture
+def mock_logging() -> Iterator[Mock]:
+    with patch("main.logging") as m:
+        yield m
+
+@pytest.fixture
+def mock_path() -> Iterator[Mock]:
+    with patch("main.Path") as m:
+        yield m
+
+@pytest.fixture
+def mock_k8s_config() -> Iterator[Mock]:
+    with patch("main.config") as m:
+        yield m
+
+@pytest.fixture
+def mock_k8s_client() -> Iterator[Mock]:
+    with patch("main.CoreV1Api") as m:
+        yield m
+
+
+def test_main_dry_run(
+    provision: AppInterfaceProvision,
+    mock_read_input_from_file: Mock,
+    mock_logging: Mock,
+) -> None:
+    mock_read_input_from_file.return_value = {"provision": provision}
+
+    with patch.dict(
+        os.environ, {"NAMESPACE": "foo", "ACTION": "Apply", "DRY_RUN": "True"}
+    ):
+        main()
+
+    mock_logging.info.assert_called_once_with("DRY_RUN does not store any secret")
+
+def test_main_destroy(
+    provision: AppInterfaceProvision,
+    mock_read_input_from_file: Mock,
+    mock_logging: Mock,
+) -> None:
+    mock_read_input_from_file.return_value = {"provision": provision}
+
+    with patch.dict(
+        os.environ, {"NAMESPACE": "foo", "ACTION": "Destroy", "DRY_RUN": "False"}
+    ):
+        main()
+
+    mock_logging.info.assert_called_once_with("No outputs management on Destroy Action")
+
+def test_main_apply_when_secret_not_exist(
+    provision: AppInterfaceProvision,
+    mock_read_input_from_file: Mock,
+    mock_logging: Mock,
+    mock_path: Mock,
+    mock_k8s_config: Mock,
+    mock_k8s_client: Mock,
+) -> None:
+    expected_secret = V1Secret(
+            api_version="v1",
+            metadata=V1ObjectMeta(
+                name=DEFAULT_EXPECTED_SECRET_NAME,
+                annotations=provision.model_dump(exclude={"module_provision_data"}),
+            ),
+            data=DEFAULT_EXPECTED_OUTPUTS,
+        )
+    mock_read_input_from_file.return_value = {"provision": provision}
+    mock_path.return_value.read_text.return_value = DEFAULT_TERRAFORM_OUTPUT
+    mock_k8s_client.return_value.read_namespaced_secret.side_effect = ApiException(status=404)
+
+    with patch.dict(
+        os.environ, {"NAMESPACE": "foo", "ACTION": "Apply", "DRY_RUN": "False"}
+    ):
+        main()
+
+    mock_logging.info.assert_called_once_with("Secret does not exist: Creating")
+    mock_k8s_client.return_value.create_namespaced_secret.assert_called_once_with(
+        namespace="foo",
+        body=expected_secret,
+    )
+
+def test_main_apply_when_secret_exist(
+    provision: AppInterfaceProvision,
+    mock_read_input_from_file: Mock,
+    mock_logging: Mock,
+    mock_path: Mock,
+    mock_k8s_config: Mock,
+    mock_k8s_client: Mock,
+) -> None:
+    expected_secret = V1Secret(
+        api_version="v1",
+        metadata=V1ObjectMeta(
+            name=DEFAULT_EXPECTED_SECRET_NAME,
+            annotations=provision.model_dump(exclude={"module_provision_data"}),
+        ),
+        data=DEFAULT_EXPECTED_OUTPUTS,
+    )
+    mock_read_input_from_file.return_value = {"provision": provision}
+    mock_path.return_value.read_text.return_value = DEFAULT_TERRAFORM_OUTPUT
+
+    with patch.dict(
+        os.environ, {"NAMESPACE": "foo", "ACTION": "Apply", "DRY_RUN": "False"}
+    ):
+        main()
+
+    mock_logging.info.assert_called_once_with("Secret already exists: Replacing")
+    mock_k8s_client.return_value.replace_namespaced_secret.assert_called_once_with(
+        DEFAULT_EXPECTED_SECRET_NAME,
+        "foo",
+        body=expected_secret,
     )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,13 +5,13 @@ from unittest.mock import Mock, patch
 import pytest
 from external_resources_io.input import AppInterfaceProvision
 from kubernetes.client import ApiException, V1ObjectMeta, V1Secret
+
+from main import main
 from tests.conftest import (
     DEFAULT_EXPECTED_OUTPUTS,
     DEFAULT_EXPECTED_SECRET_NAME,
     DEFAULT_TERRAFORM_OUTPUT,
 )
-
-from main import main
 
 
 @pytest.fixture

--- a/tests/test_read_outputs.py
+++ b/tests/test_read_outputs.py
@@ -1,4 +1,5 @@
 import pytest
+from tests.conftest import DEFAULT_EXPECTED_OUTPUTS, DEFAULT_TERRAFORM_OUTPUT
 
 from main import read_outputs
 
@@ -13,8 +14,8 @@ from main import read_outputs
         ),
         # terraform json
         (
-            '{"output1": {"value": "output1_value"}, "output2": {"value": 12345}}',
-            {"output1": "b3V0cHV0MV92YWx1ZQ==", "output2": "MTIzNDU="},
+            DEFAULT_TERRAFORM_OUTPUT,
+            DEFAULT_EXPECTED_OUTPUTS,
         ),
     ],
 )

--- a/tests/test_read_outputs.py
+++ b/tests/test_read_outputs.py
@@ -1,7 +1,7 @@
 import pytest
-from tests.conftest import DEFAULT_EXPECTED_OUTPUTS, DEFAULT_TERRAFORM_OUTPUT
 
 from main import read_outputs
+from tests.conftest import DEFAULT_EXPECTED_OUTPUTS, DEFAULT_TERRAFORM_OUTPUT
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -96,7 +96,7 @@ wheels = [
 
 [[package]]
 name = "er-outputs-secrets"
-version = "0.2.2"
+version = "0.2.3"
 source = { virtual = "." }
 dependencies = [
     { name = "external-resources-io" },

--- a/uv.lock
+++ b/uv.lock
@@ -12,30 +12,6 @@ wheels = [
 ]
 
 [[package]]
-name = "anymarkup"
-version = "0.8.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anymarkup-core" },
-    { name = "click" },
-    { name = "configobj" },
-    { name = "json5" },
-    { name = "pyyaml" },
-    { name = "toml" },
-    { name = "xmltodict" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/23/cd/33df5e9ce5dcf72a55e39432a0d6bbc77aa7857b536a063c368aa48bdd8f/anymarkup-0.8.1.tar.gz", hash = "sha256:d125c795bd47c5f7dd5ec6aedd0691f7aa7b9ed619fde87eb56ddff17ee3e844", size = 7720 }
-
-[[package]]
-name = "anymarkup-core"
-version = "0.8.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/6a/df5abb31479b36b75aa4041e62fdd2f52810fe08f7e2ef5a9883459cf97e/anymarkup-core-0.8.1.tar.gz", hash = "sha256:603351ba6b38270f518389dc9c3f3bf0738f186ad6ec51aeb6f403bc497fb308", size = 11571 }
-
-[[package]]
 name = "cachetools"
 version = "5.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -76,33 +52,12 @@ wheels = [
 ]
 
 [[package]]
-name = "click"
-version = "8.1.8"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188 },
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
-]
-
-[[package]]
-name = "configobj"
-version = "5.0.9"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f5/c4/c7f9e41bc2e5f8eeae4a08a01c91b2aea3dfab40a3e14b25e87e7db8d501/configobj-5.0.9.tar.gz", hash = "sha256:03c881bbf23aa07bccf1b837005975993c4ab4427ba57f959afdd9d1a2386848", size = 101518 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/c4/0679472c60052c27efa612b4cd3ddd2a23e885dcdc73461781d2c802d39e/configobj-5.0.9-py2.py3-none-any.whl", hash = "sha256:1ba10c5b6ee16229c79a05047aeda2b55eb4e80d7c7d8ecf17ec1ca600c79882", size = 35615 },
 ]
 
 [[package]]
@@ -144,7 +99,6 @@ name = "er-outputs-secrets"
 version = "0.2.2"
 source = { virtual = "." }
 dependencies = [
-    { name = "anymarkup" },
     { name = "external-resources-io" },
     { name = "kubernetes" },
     { name = "pydantic" },
@@ -160,30 +114,30 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anymarkup", specifier = "~=0.8.1" },
-    { name = "external-resources-io", specifier = "~=0.5.1" },
-    { name = "kubernetes", specifier = "~=31.0.0" },
-    { name = "pydantic", specifier = "~=2.10.0" },
+    { name = "external-resources-io", specifier = "==0.6.1" },
+    { name = "kubernetes", specifier = "==32.0.1" },
+    { name = "pydantic", specifier = "==2.10.6" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = "~=1.13" },
-    { name = "pytest", specifier = "~=8.3" },
-    { name = "pytest-cov", specifier = "~=6.0" },
-    { name = "ruff", specifier = "~=0.7" },
+    { name = "mypy", specifier = "==1.15.0" },
+    { name = "pytest", specifier = "==8.3.5" },
+    { name = "pytest-cov", specifier = "==6.0.0" },
+    { name = "ruff", specifier = "==0.11.0" },
 ]
 
 [[package]]
 name = "external-resources-io"
-version = "0.5.1"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
+    { name = "pydantic-settings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/9d/78cdb09adb7473e80511566f692361b51a8b3ca6c6a6a589c36db4d4f06a/external_resources_io-0.5.1.tar.gz", hash = "sha256:c440fb1bd1ac8e6d4c1c5df5fdc325c3911e350e0c62565975c0446df05ea57a", size = 7890 }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/d9/74b3671eb2a96a67bb729fe4194ca45e56f25873650a73c2df2ba88fe85b/external_resources_io-0.6.1.tar.gz", hash = "sha256:90d02801c2d8c2b478ac200981b1fae3e45a46e62b3f685006a4bc93e3481459", size = 9050 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/a9/0f319f2c7fc894283fc7dc29ed30d83bbc12ce5369d85c6b92d7cd1f5041/external_resources_io-0.5.1-py3-none-any.whl", hash = "sha256:4a7681e1653a2af74c72930b07e246128a1a1d592a9fff20cbd45cdd27f3c64e", size = 9578 },
+    { url = "https://files.pythonhosted.org/packages/89/5a/2996db655a4e88355c6a7ed2997b45ae9c35b93dea24e1949677e0961413/external_resources_io-0.6.1-py3-none-any.whl", hash = "sha256:e2504477f3bab2fa720304702cc65b35fec2b6ef317341389edad0f31f96b899", size = 11734 },
 ]
 
 [[package]]
@@ -219,17 +173,8 @@ wheels = [
 ]
 
 [[package]]
-name = "json5"
-version = "0.10.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/85/3d/bbe62f3d0c05a689c711cff57b2e3ac3d3e526380adb7c781989f075115c/json5-0.10.0.tar.gz", hash = "sha256:e66941c8f0a02026943c52c2eb34ebeb2a6f819a0be05920a6f5243cd30fd559", size = 48202 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/42/797895b952b682c3dafe23b1834507ee7f02f4d6299b65aaa61425763278/json5-0.10.0-py3-none-any.whl", hash = "sha256:19b23410220a7271e8377f81ba8aacba2fdd56947fbb137ee5977cbe1f5e8dfa", size = 34049 },
-]
-
-[[package]]
 name = "kubernetes"
-version = "31.0.0"
+version = "32.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -244,9 +189,9 @@ dependencies = [
     { name = "urllib3" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/bd/ffcd3104155b467347cd9b3a64eb24182e459579845196b3a200569c8912/kubernetes-31.0.0.tar.gz", hash = "sha256:28945de906c8c259c1ebe62703b56a03b714049372196f854105afe4e6d014c0", size = 916096 }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/e8/0598f0e8b4af37cd9b10d8b87386cf3173cb8045d834ab5f6ec347a758b3/kubernetes-32.0.1.tar.gz", hash = "sha256:42f43d49abd437ada79a79a16bd48a604d3471a117a8347e87db693f2ba0ba28", size = 946691 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/a8/17f5e28cecdbd6d48127c22abdb794740803491f422a11905c4569d8e139/kubernetes-31.0.0-py2.py3-none-any.whl", hash = "sha256:bf141e2d380c8520eada8b351f4e319ffee9636328c137aa432bc486ca1200e1", size = 1857013 },
+    { url = "https://files.pythonhosted.org/packages/08/10/9f8af3e6f569685ce3af7faab51c8dd9d93b9c38eba339ca31c746119447/kubernetes-32.0.1-py2.py3-none-any.whl", hash = "sha256:35282ab8493b938b08ab5526c7ce66588232df00ef5e1dbe88a419107dc10998", size = 1988070 },
 ]
 
 [[package]]
@@ -365,6 +310,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/82/c79424d7d8c29b994fb01d277da57b0a9b09cc03c3ff875f9bd8a86b2145/pydantic_settings-2.8.1.tar.gz", hash = "sha256:d5c663dfbe9db9d5e1c646b2e161da12f0d734d422ee56f567d0ea2cee4e8585", size = 83550 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/53/a64f03044927dc47aafe029c42a5b7aabc38dfb813475e0e1bf71c4a59d0/pydantic_settings-2.8.1-py3-none-any.whl", hash = "sha256:81942d5ac3d905f7f3ee1a70df5dfb62d5569c12f51a5a647defc1c3d9ee2e9c", size = 30839 },
+]
+
+[[package]]
 name = "pytest"
 version = "8.3.5"
 source = { registry = "https://pypi.org/simple" }
@@ -402,6 +360,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863 },
 ]
 
 [[package]]
@@ -496,15 +463,6 @@ wheels = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.10.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588 },
-]
-
-[[package]]
 name = "tomli"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -548,13 +506,4 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e6/30/fba0d96b4b5fbf5948ed3f4681f7da2f9f64512e1d303f94b4cc174c24a5/websocket_client-1.8.0.tar.gz", hash = "sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da", size = 54648 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/84/44687a29792a70e111c5c477230a72c4b957d88d16141199bf9acb7537a3/websocket_client-1.8.0-py3-none-any.whl", hash = "sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526", size = 58826 },
-]
-
-[[package]]
-name = "xmltodict"
-version = "0.14.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/50/05/51dcca9a9bf5e1bce52582683ce50980bcadbc4fa5143b9f2b19ab99958f/xmltodict-0.14.2.tar.gz", hash = "sha256:201e7c28bb210e374999d1dde6382923ab0ed1a8a5faeece48ab525b7810a553", size = 51942 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/45/fc303eb433e8a2a271739c98e953728422fa61a3c1f36077a49e395c972e/xmltodict-0.14.2-py2.py3-none-any.whl", hash = "sha256:20cc7d723ed729276e808f26fb6b3599f786cbc37e06c65e192ba77c40f20aac", size = 9981 },
 ]


### PR DESCRIPTION
During blue/green deployment, terraform flow is skipped, no outputs file generated, treat missing file as skip outputs management.

[APPSRE-11434](https://issues.redhat.com/browse/APPSRE-11434)